### PR TITLE
Revert "Update dependency vue to v3"

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "rimraf": "3.0.2",
     "ts-jest": "27.1.5",
     "typescript": "4.7.4",
-    "vue": "3.2.37",
+    "vue": "2.6.14",
     "vue-apollo": "3.1.0",
     "vue-class-component": "7.2.6",
     "vue-property-decorator": "9.1.2"


### PR DESCRIPTION
Reverts equalogic/vue-apollo-smart-ops#140

Broken dependency update was auto-merged in error.